### PR TITLE
Change link format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 
 
 gem "webrick", "~> 1.8"
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -208,7 +208,7 @@ date_format: "%B %-d, %Y"
 timezone: "Europe/Berlin"
 markdown: kramdown
 highlighter: rouge
-permalink: /:year-:month-:day-:title/
+permalink: /:year/:month/:day/:title/
 paginate: 5
 
 kramdown:
@@ -249,6 +249,7 @@ include:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/_posts/2023-09-16-custom-keyboard-layouts-with-xkb.md
+++ b/_posts/2023-09-16-custom-keyboard-layouts-with-xkb.md
@@ -4,6 +4,7 @@ title: Custom Keyboard Layouts with xkb
 subtitle: How to define and install a custom keyboard layout
 author: cmeissner
 tags: [custom keyboard layout, keyboard layout, keyboard variant, ubuntu, fedora, X11, xkb, Wayland]
+redirect_from: /2023-09-16-custom-keyboard-layouts-with-xkb/
 ---
 
 There are different reasons why the definition of custom keyboard layouts can become necessary.


### PR DESCRIPTION
To be more compliant with default jekyll environments we change the link format form `YYYY-MM-DD-<title` to `YYYY/MM/DD/<title>`. As there are many old posts with links in the old format out in the wilde we add `jekyll-redirect-from` plugin to rewrite old links to new link style