### PR TITLE
Change link format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 
 
 gem "webrick", "~> 1.8"
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -208,7 +208,7 @@ date_format: "%B %-d, %Y"
 timezone: "Europe/Berlin"
 markdown: kramdown
 highlighter: rouge
-permalink: /:year-:month-:day-:title/
+permalink: /:year/:month/:day/:title/
 paginate: 5
 
 kramdown:
@@ -249,6 +249,7 @@ include:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/_posts/2020-12-20-monkey-home-is-open.md
+++ b/_posts/2020-12-20-monkey-home-is-open.md
@@ -5,12 +5,13 @@ subtitle: Codeaffen project homepage started today
 thumbnail-img: /assets/img/codeaffen_wo_bg.png
 author: cmeissner
 tags: [project, homepage, welcome]
+redirect_from: /2020-12-20-monkey-home-is-open/
 ---
 
 After creating some code we started today our homepage. It comes as blog and is completly managed via github as we like most of githubs features a lot.
 What can you expect here. Beside blog posts to our projects and how to work on it we think we spot on other interesting topics we encouter in our daily work.
 
-![codeaffen](../assets/img/codeaffen_wo_bg.png){: .mx-auto.d-block :}
+![codeaffen](/assets/img/codeaffen_wo_bg.png){: .mx-auto.d-block :}
 
 ## Contributing
 

--- a/_posts/2020-12-22-hieradata-announcement-0.1.0.md
+++ b/_posts/2020-12-22-hieradata-announcement-0.1.0.md
@@ -7,6 +7,7 @@ gh-repo: codeaffen/ansible-hiera-data
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
 last-updated: 2021-01-05
+redirect_from: /2020-12-22-hieradata-announcement-0.1.0/
 ---
 
 We are proud to announce the release of version 0.1.0 of our new ansible collection.

--- a/_posts/2021-01-04-phpypam-announcement-1.0.1.md
+++ b/_posts/2021-01-04-phpypam-announcement-1.0.1.md
@@ -7,6 +7,7 @@ gh-repo: codeaffen/phpypam
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
 last-updated: 2021-01-05
+redirect_from: /2021-01-04-phpypam-announcement-1.0.1/
 ---
 
 We are proud to announce the release of version 1.0.1 of phpypam.

--- a/_posts/2021-01-05-contact-us-at-keybase.md
+++ b/_posts/2021-01-05-contact-us-at-keybase.md
@@ -5,6 +5,7 @@ subtitle: Let's get in touch!
 thumbnail-img: /assets/img/codeaffen_wo_bg.png
 tags: [project, homepage, contact, keybase]
 author: gmzabos
+redirect_from: /2021-01-05-contact-us-at-keybase/
 ---
 
 

--- a/_posts/2021-01-07-writing-phpipam-ansible-modules.md
+++ b/_posts/2021-01-07-writing-phpipam-ansible-modules.md
@@ -6,6 +6,7 @@ tags: [project, phpipam, ansible, contributing]
 author: cmeissner
 gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
+redirect_from: /2021-01-07-writing-phpipam-ansible-modules/
 ---
 
 We started to develop our [phpipam-ansible-modules](https://github.com/codeaffen/phpipam-ansible-modules) to manage phpIPAM installation from within Ansible.
@@ -32,7 +33,7 @@ You should also look into phpIPAM's WebUI as the API documentation does not say 
 
 For most controllers `name` is a mandatory parameter, in our case `number` is also required.
 
-![new vlan dialog](../assets/img/phpipam_new_vlan_dialog.jpg)
+![new vlan dialog](/assets/img/phpipam_new_vlan_dialog.jpg)
 
 In the `Add VLAN` dialog is also defined that `default` is the default L2 Domain.
 

--- a/_posts/2021-01-25-virtual-envs.md
+++ b/_posts/2021-01-25-virtual-envs.md
@@ -4,6 +4,7 @@ title: Using virtual environments for development
 subtitle: Isolate your sandbox
 tags: [development, python, ruby, node.js]
 author: cmeissner
+redirect_from: /2021-01-25-virtual-envs/
 ---
 
 If you develop on different projects in different languages it can happen that different versions of the respective scriptin languges are used.

--- a/_posts/2021-02-02-hbase-coprocessors.md
+++ b/_posts/2021-02-02-hbase-coprocessors.md
@@ -4,6 +4,7 @@ title: How to remove coprocessor table attributes
 subtitle: Coprocessors in HBase
 tags: [apache, hadoop, hbase, phoenix, coprocessor]
 author: gmzabos
+redirect_from: /2021-02-02-hbase-coprocessors/
 ---
 
 {: .box-warning}

--- a/_posts/2021-03-02-self-hosted-bitwarden.md
+++ b/_posts/2021-03-02-self-hosted-bitwarden.md
@@ -4,6 +4,7 @@ title: Bitwarden on premise
 subtitle: Operate your own bitwarden infrastructure
 tags: [bitwarden, password managers, docker, container]
 author: cmeissner
+redirect_from: /2021-03-02-self-hosted-bitwarden/
 ---
 
 ## Why bitwarden?
@@ -58,7 +59,7 @@ We try our test installation with the chrome extension. For that we created a fr
 
 You need to open the settings dialog gear symbol on the upper left corner and write the url to your installation in the server field. All other field can be left blank but you can also put your url in there. Finally you need to click the save button in the upper right corner.
 
-![Bitwarden extension settings](../../assets/img/bitwarden_ext_settings.png)
+![Bitwarden extension settings](/assets/img/bitwarden_ext_settings.png)
 
 Now you can create a new account on your server and start to use is like you would use bitwarden cloud.
 

--- a/_posts/2021-03-09-stellar-issue-asset.md
+++ b/_posts/2021-03-09-stellar-issue-asset.md
@@ -4,6 +4,7 @@ title: How to issue an asset on Stellar
 subtitle: AFFEN goes live
 tags: [poc, blockchain, stellar, token, asset, github]
 author: gmzabos
+redirect_from: /2021-03-09-stellar-issue-asset/
 ---
 
 ## Intro: What is Stellar?

--- a/_posts/2021-03-22-p3exporter-announcement-1.0.0.md
+++ b/_posts/2021-03-22-p3exporter-announcement-1.0.0.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, phpypam]
 gh-repo: codeaffen/p3exporter
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2021-03-22-p3exporter-announcement-1.0.0/
 ---
 
 We are proud to announce the release of version 1.0.0 of p3exporter. We now on the road to provide real life collectors. Starting with `loadavg`. We plan to provide more and more real life collectors to use this exporter not only for own development.

--- a/_posts/2021-03-30-p3exporter-announcement-1.1.0.md
+++ b/_posts/2021-03-30-p3exporter-announcement-1.1.0.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, phpypam]
 gh-repo: codeaffen/p3exporter
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2021-03-30-p3exporter-announcement-1.1.0/
 ---
 
 We are proud to announce the release of version 1.1.0 of p3exporter.

--- a/_posts/2021-04-12-p3exporter-announcement-1.1.1.md
+++ b/_posts/2021-04-12-p3exporter-announcement-1.1.1.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, phpypam]
 gh-repo: codeaffen/p3exporter
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2021-04-12-p3exporter-announcement-1.1.1/
 ---
 
 We are proud to announce the release of version 1.1.1 of p3exporter.

--- a/_posts/2021-06-07-writing-p3exporter-collectors.md
+++ b/_posts/2021-06-07-writing-p3exporter-collectors.md
@@ -115,6 +115,7 @@ class HowtoExampleCollector(CollectorBase):
 
     def __init__(self, config: CollectorConfig):
 
+redirect_from: /2021-06-07-writing-p3exporter-collectors/
         super(HowtoExampleCollector, self).__init__(config)
 
         self.our_opt = self.opts.pop("our_opt", None)

--- a/_posts/2021-07-16-oh-my-zsh-walkthrough.md
+++ b/_posts/2021-07-16-oh-my-zsh-walkthrough.md
@@ -4,6 +4,7 @@ title: Oh my zsh walkthrough
 subtitle: Get the best out of your Z shell
 tags: [development, shell, zsh, ohmyzsh, OMZ, environment, configuration, themes, plugins]
 author: cmeissner
+redirect_from: /2021-07-16-oh-my-zsh-walkthrough/
 ---
 
 Configuring your shell to get the best out of it can become a tedious task. Some common tasks are:

--- a/_posts/2021-09-06-phpypam-announcement-1.0.2.md
+++ b/_posts/2021-09-06-phpypam-announcement-1.0.2.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, phpypam]
 gh-repo: codeaffen/phpypam
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2021-09-06-phpypam-announcement-1.0.2/
 ---
 
 We are proud to announce the release of version 1.0.2 of phpypam.

--- a/_posts/2021-09-17-migrate-helm-charts.md
+++ b/_posts/2021-09-17-migrate-helm-charts.md
@@ -5,6 +5,7 @@ subtitle: How to migrate from repository to registry
 tags: [kubernetes, openshift, helm, chart, repository, redhat, quay, registry]
 author: gmzabos
 last-updated: 2022-07-03
+redirect_from: /2021-09-17-migrate-helm-charts/
 ---
 
 Imagine the following situation you have an instance of ChartMuseum repository up & running for months now and it does serve Helm Charts. You also build up an instance of Red Hat Quay in parallel, but it has been solely used for storing container images until now.
@@ -23,7 +24,7 @@ With [Red Hat Quay 3.5 (GA)](https://cloud.redhat.com/blog/quay-oci-artifact-sup
 
 ### Prerequisites
 
-- ChartMuseum is up & running, serving via a known API URL (e.g. https://chartmuseum.local.net)
+- ChartMuseum is up & running, serving via a known API URL (e.g. (https://chartmuseum.local.net))
 - An admin host is up & running. The `helm` binary is release v3.x or higher (see: `helm version`), you have set an extra environment variable:
 
 ~~~shell

--- a/_posts/2021-12-06-codeaffen-irc.md
+++ b/_posts/2021-12-06-codeaffen-irc.md
@@ -4,9 +4,10 @@ title: Codeaffen on Libera.chat network
 subtitle: user and developer channels on IRC
 tags: [project, homepage, contact, irc, libera.chat]
 author: cmeissner
+redirect_from: /2021-12-06-codeaffen-irc/
 ---
 
-In January we decided to start with [keybase](2021-01-05-contact-us-at-keybase) as communication platform. Unfortunately this network is not so popular as it should be. As we don't want to use networks like slack only because all others do this we now opened two IRC channels on [Libera.chat](https://libera.chat){:target="_blank"} as this technology is well tested and a good point for finding together quick and easy. 
+In January we decided to start with [keybase](2021-01-05-contact-us-at-keybase) as communication platform. Unfortunately this network is not so popular as it should be. As we don't want to use networks like slack only because all others do this we now opened two IRC channels on [Libera.chat](https://libera.chat){:target="_blank"} as this technology is well tested and a good point for finding together quick and easy.
 
 ## User channel
 

--- a/_posts/2021-12-16-phpipam-announcement-1.4.0.md
+++ b/_posts/2021-12-16-phpipam-announcement-1.4.0.md
@@ -7,6 +7,7 @@ gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
 last-updated: 2021-12-16
+redirect_from: /2021-12-16-phpipam-announcement-1.4.0/
 ---
 
 We are proud to announce the release of version 1.4.0 of phpipam-ansible-modules.

--- a/_posts/2022-01-01-github-actions-containerized-services.md
+++ b/_posts/2022-01-01-github-actions-containerized-services.md
@@ -6,6 +6,7 @@ tags: [github, workflow, container, services, docker, end-to-end tests, ansible,
 gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2022-01-01-github-actions-containerized-services/
 ---
 
 For our [phpipam-ansible-modules](https://github.com/codeaffen/phpipam-ansible-modules){:target="_blank"} we started early to test all our modules with end-to-end tests. For that we created for each module a playbook where entities are created, updated and deleted (crud). We ran theses playbooks by hand to check if the modules worked as expected. To automate this a bit we also use loops in our used shell to iterate over all the test playbooks and check the results manually.

--- a/_posts/2022-01-15-phpipam-action-announcement-v1.md
+++ b/_posts/2022-01-15-phpipam-action-announcement-v1.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, phpipam, phpipam-aaction, github-action, 
 gh-repo: codeaffen/phpipam-action
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2022-01-15-phpipam-action-announcement-v1/
 ---
 
 We are proid to announce the release of version v1 of our phpipam-action.

--- a/_posts/2022-01-30-matrix-build-with-custom-github-action.md
+++ b/_posts/2022-01-30-matrix-build-with-custom-github-action.md
@@ -4,6 +4,7 @@ title: Build matrix in github workflows
 subtitle: Run jobs in different variations
 tags: [github, workflow, github-action, automated testing, build matrix, continuous-integration, docker]
 author: cmeissner
+redirect_from: /2022-01-30-matrix-build-with-custom-github-action/
 ---
 
 In the last blog post [github actions - containerized services](https://codeaffen.org/2022-01-01-github-actions-containerized-services/) we described how to use containerized services to run tests against a fresh phpipam installation in each test run.

--- a/_posts/2022-02-07-custom-keyboard-layout.md
+++ b/_posts/2022-02-07-custom-keyboard-layout.md
@@ -5,11 +5,12 @@ subtitle: How to define and install a custom keyboard layout
 author: cmeissner
 tags: [custom keyboard layout, keyboard layout, keyboard variant, ubuntu]
 last-updated: 2023-09-14
+redirect_from: /2022-02-07-custom-keyboard-layout/
 ---
 
 {: .box-warning}
 There is a updated version on how to make keyboard layouts available and especially safe against `xkeyboard-config` package upgrades.
-Please have a look at [Custom Keyboard Layouts with xkb](../2023-09-16-custom-keyboard-layouts-with-xkb).
+Please have a look at [Custom Keyboard Layouts with xkb](/2023-09-16-custom-keyboard-layouts-with-xkb).
 
 As a developer I prefer to use the us intl. keyboard layout as many symboles are positioned better than on the german keyboard layout.
 But on the other side I also have to write texts in german and I need to have access to all german umlauts and symboles. Unfortunately there is no layout that suited in all details to my daily needs. Here comes the ability to define a custom keyboard layout in account.
@@ -92,7 +93,7 @@ To make the recently defined variant a layout we have to define a new layout for
 
 Now you can select your newly defined layout in the configuration dialog.
 
-![Select your keyboard layout](../assets/img/select_keyboard_layout.png){: .mx-auto.d-block :}
+![Select your keyboard layout](/assets/img/select_keyboard_layout.png){: .mx-auto.d-block :}
 
 {: .box-note}
 **Note:** It can be necessary to logout and relogin to make the layout available.

--- a/_posts/2022-03-01-parsedmarc-guide.md
+++ b/_posts/2022-03-01-parsedmarc-guide.md
@@ -6,6 +6,7 @@ cover-img: /assets/img/parsedmarc_header.png
 thumbnail-img: /assets/img/DMARC-logo.png
 author: cmeissner
 tags: [parsedmarc, dmarc, spf, dkim, anti spam, elasticsearch, kibana]
+redirect_from: /2022-03-01-parsedmarc-guide/
 ---
 
 DMARC stands for "Domain-based Message Authentication, Reporting and Conformance". It is as protocol for email authentication, policy and reporting.

--- a/_posts/2022-03-07-phpipam-announcement-1.5.0.md
+++ b/_posts/2022-03-07-phpipam-announcement-1.5.0.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, pam, phpipam, phpipam-ansible-modules]
 gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2022-03-07-phpipam-announcement-1.5.0/
 ---
 
 We are proud to announce the release of version 1.5.0 of phpipam-ansible-modules.

--- a/_posts/2022-09-12-phpipam-announcement-1.6.0.md
+++ b/_posts/2022-09-12-phpipam-announcement-1.6.0.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, pam, phpipam, phpipam-ansible-modules]
 gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2022-09-12-phpipam-announcement-1.6.0/
 ---
 
 We are proud to announce the release of version 1.6.0 of phpipam-ansible-modules.

--- a/_posts/2023-02-05-phpipam-announcement-1.6.1.md
+++ b/_posts/2023-02-05-phpipam-announcement-1.6.1.md
@@ -6,6 +6,7 @@ tags: [project, release, announcement, pam, phpipam, phpipam-ansible-modules]
 gh-repo: codeaffen/phpipam-ansible-modules
 gh-badge: [star, watch, fork, follow]
 author: cmeissner
+redirect_from: /2023-02-05-phpipam-announcement-1.6.1/
 ---
 
 We are proud to announce the release of version 1.6.1 of phpipam-ansible-modules.

--- a/_posts/2023-08-12-manage_localvolumeset.md
+++ b/_posts/2023-08-12-manage_localvolumeset.md
@@ -4,6 +4,7 @@ title: Managing LocalVolumeSet of Local Storage Operator
 subtitle: How to manage disks of a Local Volume Set
 tags: [openshift, operator, local-storage-operator, localvolumeset, localdiscovery]
 author: cmeissner
+redirect_from: /2023-08-12-manage_localvolumeset/
 ---
 
 If you use OpenShift Data Foundation in you environment and you want to use local disks of your worker/infra nodes then the Local Storage operator could be your choice.

--- a/_posts/2023-08-26-signal_spellcheck_setup.md
+++ b/_posts/2023-08-26-signal_spellcheck_setup.md
@@ -4,6 +4,7 @@ title: Signal Spellcheck
 subtitle: Setting up multiple languages for spell checking
 tags: [signal, signal-desktop, desktop, spellcheck, language, locales, configuration]
 author: cmeissner
+redirect_from: /2023-08-26-signal_spellcheck_setup/
 ---
 Using `Signal` as the messenger of your choice is always a good idea. It provides **State-of-the-art end-to-end encryption**, **Text-**, **Voice-** and **Video-Chats**. You can chat 1:1 or in **Groups**. There are no adds in and it is always free for everyone. And finally it provides a desktop client for the main desktop OSes (Windows, OSX and Linux).
 

--- a/_posts/2023-09-03-phpipam-announcement-1.7.0.md
+++ b/_posts/2023-09-03-phpipam-announcement-1.7.0.md
@@ -1,4 +1,5 @@
 ---
+redirect_from: /2023-09-03-phpipam-announcement-1.7.0/
 layout: post
 title: codeaffen.phpipam v1.7.0
 subtitle: phpipam ansible modules 1.7.0 has been released

--- a/_posts/2023-09-16-custom-keyboard-layouts-with-xkb.md
+++ b/_posts/2023-09-16-custom-keyboard-layouts-with-xkb.md
@@ -4,6 +4,7 @@ title: Custom Keyboard Layouts with xkb
 subtitle: How to define and install a custom keyboard layout
 author: cmeissner
 tags: [custom keyboard layout, keyboard layout, keyboard variant, ubuntu, fedora, X11, xkb, Wayland]
+redirect_from: /2023-09-16-custom-keyboard-layouts-with-xkb/
 ---
 
 There are different reasons why the definition of custom keyboard layouts can become necessary.
@@ -25,7 +26,7 @@ The configuration for `xkb` can be found in `/usr/share/X11/xkb`. There are two 
 2. `rules`, provides files for mapping a definition to a configuration
 
 {: .note-warning}
-In our former article ([Custom Keyboard Layouts on Ubuntu](../2022-02-07-custom-keyboard-layout)) we did our changes within these directories. This procedure is not that good, as custom changes will be reverted on each `xkeyboard-config` package upgrade.
+In our former article ([Custom Keyboard Layouts on Ubuntu](/2022-02-07-custom-keyboard-layout)) we did our changes within these directories. This procedure is not that good, as custom changes will be reverted on each `xkeyboard-config` package upgrade.
 
 The following text will focus on how to configure `xkb` with custom keyboard layouts and make them per user or globally available and upgrade safe.
 
@@ -126,7 +127,7 @@ To make your layouts discoverable, tools rely on `evdev.xml` file. To add your c
 3. The description will be shown in the configuration dialog (e.g. in Gnome, Tray chooser)
 4. We bound the layout to all languages with ISO ID `eng` and `deu` as well as countries with ISO ID `US` and `DE`
 
-![Keyboard Layout Tray Chooser](../assets/img/select_keyboard_layout_tray.png){:.mx-auto.d-block :}
+![Keyboard Layout Tray Chooser](/assets/img/select_keyboard_layout_tray.png){:.mx-auto.d-block :}
 
 ## set up your keyboard
 
@@ -135,7 +136,7 @@ To make your layouts discoverable, tools rely on `evdev.xml` file. To add your c
 
 Now you can select your newly defined layout in the configuration dialog.
 
-![Select your keyboard layout](../assets/img/select_keyboard_layout_fedora.png){:.mx-auto.d-block :}
+![Select your keyboard layout](/assets/img/select_keyboard_layout_fedora.png){:.mx-auto.d-block :}
 
 From now on, you can use all the defined key combos as you would normally do.
 


### PR DESCRIPTION
To be more compliant with default jekyll environments we change the link
format form `YYYY-MM-DD-<title` to `YYYY/MM/DD/<title>`.
As there are many old posts with links in the old format out in the
wilde we add `jekyll-redirect-from` plugin to rewrite old links to new link style

To achieve this there were some internal links to be fixed too. All old
post got property `redirect_from` to handle the necessary rewrites.